### PR TITLE
Categorization of Sentiment, Equities, Nifty Indices and Trend Detector endpoints in Swagger.

### DIFF
--- a/fin_maestro_kin/modules/data_toolkit/nse/nse_equities.py
+++ b/fin_maestro_kin/modules/data_toolkit/nse/nse_equities.py
@@ -6,7 +6,7 @@ import pandas as pd
 import re
 import json
 
-router = APIRouter()
+router = APIRouter(tags=["Equities"])
 
     
 def security_wise_archive(symbol, start_date, end_date, series="ALL"):   
@@ -23,7 +23,7 @@ def security_wise_archive(symbol, start_date, end_date, series="ALL"):
 
 
 # Example usage - http://localhost:8000/equities/security-archives?symbol=TCS&start_date=04-01-2024&end_date=14-01-2024&series=ALL
-@router.get("/equities/security-archives")
+@router.get("/equities/security-archives",tags=["Equities"])
 def get_security_wise_archive(
     symbol: str = Query(..., title="Symbol", description="Stock symbol"),
     start_date: str = Query(..., title="From Date", description="Start date for historical data in dd-mm-yyyy format"),
@@ -52,7 +52,7 @@ def bulk_deals_archives(start_date, end_date):
 
 
 # Example usage - http://localhost:8000/equities/bulk-deals-archives?start_date=28-01-2024&end_date=04-02-2024
-@router.get("/equities/bulk-deals-archives")
+@router.get("/equities/bulk-deals-archives",tags=["Equities"])
 def get_bulk_deals_archives(
     start_date: str = Query(..., title="From Date", description="Start date for historical data in dd-mm-yyyy format"),
     end_date: str = Query(..., title="To Date", description="End date for historical data in dd-mm-yyyy format"),  
@@ -79,7 +79,7 @@ def block_deals_archives(start_date, end_date):
 
 
 # Example usage - http://localhost:8000/equities/block-deals-archives?start_date=28-01-2024&end_date=04-02-2024
-@router.get("/equities/block-deals-archives")
+@router.get("/equities/block-deals-archives",tags=["Equities"])
 def get_block_deals_archives(
     start_date: str = Query(..., title="From Date", description="Start date for historical data in dd-mm-yyyy format"),
     end_date: str = Query(..., title="To Date", description="End date for historical data in dd-mm-yyyy format"),  
@@ -106,7 +106,7 @@ def short_selling_archives(start_date, end_date):
 
 
 #Example usage - http://localhost:8000/equities/short-selling?start_date=28-01-2024&end_date=04-02-2024
-@router.get("/equities/short-selling-archives")
+@router.get("/equities/short-selling-archives",tags=["Equities"])
 def get_short_selling_archives(
     start_date: str = Query(..., title="From Date", description="Start date for historical data in dd-mm-yyyy format"),
     end_date: str = Query(..., title="To Date", description="End date for historical data in dd-mm-yyyy format"),  
@@ -137,7 +137,7 @@ def corporate_actions(start_date, end_date):
     
 
 # Example usage - http://localhost:8000/equities/corporate-actions?start_date=28-01-2024&end_date=04-02-2024
-@router.get("/equities/corporate-actions")
+@router.get("/equities/corporate-actions",tags=["Equities"])
 def get_corporate_actions(
     start_date: str = Query(..., title="From Date", description="Start date for historical data in dd-mm-yyyy format"),
     end_date: str = Query(..., title="To Date", description="End date for historical data in dd-mm-yyyy format"),  
@@ -162,7 +162,7 @@ def nse_monthly_most_active_securities():
     
 
 # Example usage - http://localhost:8000/equities/most-active-securities
-@router.get("/equities/most-active-securities")
+@router.get("/equities/most-active-securities",tags=["Equities"])
 def get_nse_monthly_most_active_securities():
     try:
         historical_data = nse_monthly_most_active_securities()
@@ -186,7 +186,7 @@ def nse_monthly_advances_and_declines(year):
 
 
 #Example usage - http://localhost:8000/equities/advances-declines?year=2024
-@router.get("/equities/advances-declines")
+@router.get("/equities/advances-declines",tags=["Equities"])
 def get_nse_monthly_advances_and_declines(
     year: str = Query(..., title="Year", description="Year for historical data in format YYYY"), 
 ):
@@ -214,7 +214,7 @@ def nse_capital_market_monthly_settlement_stats(financial_year):
 
 
 #Example usage - http://localhost:8000/equities/monthly-settlement-stats/capital-market?financial_year=2022-2023
-@router.get("/equities/monthly-settlement-stats/capital-market")
+@router.get("/equities/monthly-settlement-stats/capital-market",tags=["Equities"])
 def get_nse_capital_market_monthly_settlement_stats(
     financial_year: str = Query(..., title="Year", description="Financial Year for historical data in format YYYY-YYYY"), 
 ):
@@ -243,7 +243,7 @@ def nse_fno_monthly_settlement_stats(financial_year):
 
 
 #Example usage - http://localhost:8000/equities/monthly-settlement-stats/fno?financial_year=2022-2023
-@router.get("/equities/monthly-settlement-stats/fno")
+@router.get("/equities/monthly-settlement-stats/fno",tags=["Equities"])
 def get_nse_fno_monthly_settlement_stats(
     financial_year: str = Query(..., title="Year", description="Financial Year for historical data in format YYYY-YYYY"), 
 ):
@@ -282,7 +282,7 @@ def pcr_stocks_scraper(symbol):
 
 
 #Example usage - http://127.0.0.1:8000/equities/stock-pcr?symbol=RELIANCE
-@router.get("/equities/stock-pcr")
+@router.get("/equities/stock-pcr",tags=["Equities"])
 def get_pcr(symbol: str = Query(..., title="Symbol", description="Stock symbol")):
     pcr_value = pcr_stocks_scraper(symbol)
     return {"symbol": symbol, "pcr_value": pcr_value}

--- a/fin_maestro_kin/modules/data_toolkit/nse/nse_indices.py
+++ b/fin_maestro_kin/modules/data_toolkit/nse/nse_indices.py
@@ -5,7 +5,7 @@ import requests
 import json
 import pandas as pd
 
-router = APIRouter()
+router = APIRouter(tags=["Nifty Indices"])
 
 niftyindices_headers = {
     'Connection': 'keep-alive',
@@ -34,7 +34,7 @@ def index_history(symbol, start_date, end_date):
 
 
 #Example usage - 127.0.0.1:8000/niftyindices/history?symbol=NIFTY 50&start_date=10-Jan-2024&end_date=12-Jan-2024
-@router.get("/niftyindices/history")
+@router.get("/niftyindices/history",tags=["Nifty Indices"])
 def get_niftyindices_history(
     symbol: str = Query(..., title="Symbol", description="Nifty indices symbol"),
     start_date: str = Query(..., title="Start Date", description="Start date for historical data in dd-mmm-yyyy format"),
@@ -56,7 +56,7 @@ def index_pe_pb_div(symbol,start_date,end_date):
 
 
 #Example usage - #Example usage - 127.0.0.1:8000/niftyindices/ratios?symbol=NIFTY 50&start_date=10-Jan-2024&end_date=12-Jan-2024
-@router.get("/niftyindices/ratios")
+@router.get("/niftyindices/ratios",tags=["Nifty Indices"])
 def get_niftyindices_ratios(
     symbol: str = Query(..., title="Symbol", description="Nifty indices symbol"),
     start_date: str = Query(..., title="Start Date", description="Start date for historical data in dd-mmm-yyyy format"),
@@ -78,7 +78,7 @@ def index_total_returns(symbol,start_date,end_date):
 
 
 #Example usage - 127.0.0.1:8000/niftyindices/returns?symbol=NIFTY 50&start_date=10-Jan-2024&end_date=12-Jan-2024
-@router.get("/niftyindices/returns")
+@router.get("/niftyindices/returns",tags=["Nifty Indices"])
 def get_niftyindices_returns(
     symbol: str = Query(..., title="Symbol", description="Nifty indices symbol"),
     start_date: str = Query(..., title="Start Date", description="Start date for historical data in dd-mmm-yyyy format"),
@@ -92,7 +92,7 @@ def get_niftyindices_returns(
     
     
 #Example Usgae - http://127.0.0.1:8000/niftyindices/indice-pcr?symbol=NIFTY
-@router.get("/niftyindices/indice-pcr")
+@router.get("/niftyindices/indice-pcr",tags=["Nifty Indices"])
 def get_pcr(
     symbol: str = Query(..., title="Symbol", description="Indice symbol")
 ):
@@ -132,7 +132,7 @@ def india_vix_history(start_date, end_date):
 
 
 # Example usage - http://localhost:8000/niftyindices/india-vix?start_date=28-01-2024&end_date=04-02-2024
-@router.get("/niftyindices/india-vix")
+@router.get("/niftyindices/india-vix",tags=["Nifty Indices"])
 def get_india_vix_history(
     start_date: str = Query(..., title="From Date", description="Start date for historical data in dd-mm-yyyy format"),
     end_date: str = Query(..., title="To Date", description="End date for historical data in dd-mm-yyyy format"),  

--- a/fin_maestro_kin/modules/sentiment_analysis/sentiment_analysis.py
+++ b/fin_maestro_kin/modules/sentiment_analysis/sentiment_analysis.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Query
 from .pcr_data import pcr_indice_scraper, pcr_stocks_scraper
 
-router = APIRouter()
+router = APIRouter(tags=["Sentiment"])
 
 #Example usage - http://127.0.0.1:8000/sentiment/pcr-indice-analysis
-@router.get("/sentiment/pcr-indice-analysis")
+@router.get("/sentiment/pcr-indice-analysis",tags=["Sentiment"])
 def analyze_indices():
     try:
         pcr_anal_result = pcr_indice_analysis()
@@ -14,7 +14,7 @@ def analyze_indices():
 
 
 #Example usage - http://127.0.0.1:8000/sentiment/pcr-stocks-analysis?symbol=INFY
-@router.get("/sentiment/pcr-stocks-analysis")
+@router.get("/sentiment/pcr-stocks-analysis",tags=["Sentiment"])
 def analyze_stock(symbol: str = Query(..., title="Symbol", description="Stock symbol")):
     try:
         pcr_anal_result = pcr_stocks_analysis(symbol)

--- a/fin_maestro_kin/modules/trend_detector/trend_detector.py
+++ b/fin_maestro_kin/modules/trend_detector/trend_detector.py
@@ -10,7 +10,7 @@ import warnings
 warnings.filterwarnings("ignore")
 initial, end = dt.date.today() - dt.timedelta(days=374), dt.date.today()
 
-router = APIRouter()
+router = APIRouter(tags=["Generateplot"])
 
 
 #Example usage - http://127.0.0.1:8000/generate_plot?ticker=BSE.NS
@@ -45,7 +45,7 @@ def signals_generator(ticker, num_of_signals):
     return fig
 
 
-@router.get("/generate_plot")
+@router.get("/generate_plot",tags=["Trend Detector"])
 async def generate_plot(ticker: str = Query(..., title="Ticker", description="Stock ticker symbol"),
                         num_of_signals: int = Query(10, title="Num of Signals", description="Number of buy/sell signals to be plotted")):
     fig = signals_generator(ticker, num_of_signals)

--- a/fin_maestro_kin/modules/trend_detector/trend_detector.py
+++ b/fin_maestro_kin/modules/trend_detector/trend_detector.py
@@ -10,7 +10,7 @@ import warnings
 warnings.filterwarnings("ignore")
 initial, end = dt.date.today() - dt.timedelta(days=374), dt.date.today()
 
-router = APIRouter(tags=["Generateplot"])
+router = APIRouter(tags=["Trend Detector"])
 
 
 #Example usage - http://127.0.0.1:8000/generate_plot?ticker=BSE.NS


### PR DESCRIPTION
This pull request introduces endpoint categorization for the  endpoints in our FastAPI application. Previously, all endpoints were listed under the default category in the Swagger documentation, which could make navigation and understanding of the API structure challenging, especially as the API grows.

To address this, I've organized the endpoints into a separate category using FastAPI  tags. Now, when accessing the Swagger UI, users will find the endpoints neatly grouped under the corresponding category, improving readability and usability.

This enhancement enhances the overall organization and documentation clarity of our API, facilitating easier navigation and understanding for developers and users alike.