### PR TITLE
Clean API responses with unnecessary data, symbols

### DIFF
--- a/fin_maestro_kin/modules/data_toolkit/screener/screener_equities.py
+++ b/fin_maestro_kin/modules/data_toolkit/screener/screener_equities.py
@@ -16,7 +16,6 @@ class Helper:
             if label:
                 formatted_label = label.replace('+', '').strip()
                 formatted_reports[formatted_label] = {key: value.replace('%','').replace(',','') for key, value in report.items() if key != ""}
-                print(formatted_reports[formatted_label])
         return {'symbol': stock_name, key: formatted_reports}
     
     @staticmethod

--- a/fin_maestro_kin/modules/data_toolkit/screener/screener_equities.py
+++ b/fin_maestro_kin/modules/data_toolkit/screener/screener_equities.py
@@ -14,7 +14,7 @@ class Helper:
         for report in reports:
             label = report.get("")
             if label:
-                formatted_label = label.replace('+', '').strip()
+                formatted_label = label.replace('+', '').replace('%','').replace(',','').strip()
                 formatted_reports[formatted_label] = {key: value for key, value in report.items() if key != ""}
         return {'symbol': stock_name, key: formatted_reports}
     

--- a/fin_maestro_kin/modules/data_toolkit/screener/screener_equities.py
+++ b/fin_maestro_kin/modules/data_toolkit/screener/screener_equities.py
@@ -14,13 +14,14 @@ class Helper:
         for report in reports:
             label = report.get("")
             if label:
-                formatted_label = label.replace('+', '').replace('%','').replace(',','').strip()
-                formatted_reports[formatted_label] = {key: value for key, value in report.items() if key != ""}
+                formatted_label = label.replace('+', '').strip()
+                formatted_reports[formatted_label] = {key: value.replace('%','').replace(',','') for key, value in report.items() if key != ""}
+                print(formatted_reports[formatted_label])
         return {'symbol': stock_name, key: formatted_reports}
     
     @staticmethod
     def process_key_metrics_data(value):
-        return value.replace('\n', '').replace('\u20b9', '').replace('          ', '').replace('         ', '').replace('       ','').replace(' ','').replace(',','').replace('Cr.','Cr')
+        return value.replace('\n', '').replace('\u20b9', '').replace('          ', '').replace('         ', '').replace('       ','').replace(' ','').replace(',','').replace('Cr.','').replace('%','')
     
     @staticmethod
     def handle_key_metrics_response(response, company_code):


### PR DESCRIPTION
This PR aims to cleanse API responses for them to be free of needless data.
Following APIs were changed:
1. screener-equities/ratios:
![image](https://github.com/devfinwiz/Fin-Maestro-Kin/assets/80447844/4e277d11-caa7-4532-aa93-3d230b972b4b)
2. screener-equities/key-metrics:
![image](https://github.com/devfinwiz/Fin-Maestro-Kin/assets/80447844/8590f6fa-3699-43d8-9326-ee51bf15e90b)
3. screener-equities/balance-sheet:
![image](https://github.com/devfinwiz/Fin-Maestro-Kin/assets/80447844/ff293ff3-7811-4171-a6b4-6c909b4b1ffa)
4. screener-equities/cash-flow:
![image](https://github.com/devfinwiz/Fin-Maestro-Kin/assets/80447844/9ddbe402-9d8a-4fb9-9c3a-23fc3d09bc06)
5. screener-equities/shareholding-pattern:
![image](https://github.com/devfinwiz/Fin-Maestro-Kin/assets/80447844/34380a45-42d8-4544-9bb3-0436434e5cab)
6. screener-equities/quarterly-result:
![image](https://github.com/devfinwiz/Fin-Maestro-Kin/assets/80447844/1764f702-afac-413c-944f-f54f3d1ccf6f)



